### PR TITLE
fix(docs): Update extension that gets converted

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ then run;
 That will spin up the `df-plugin-dev-server` and all you'll need to do is create a new plugin with this code:
 
 ```
-export { default } from "http://127.0.0.1:2222/plugin.ts?dev"
+// `.ts` extensions become `.js` when being served
+export { default } from "http://127.0.0.1:2222/plugin.js?dev"
 ```
 
 This will setup some configuration client side to pull in code from your local machine. (HMR soon tm)


### PR DESCRIPTION
Just found that `.ts` extensions get converted to `.js` after bundling.